### PR TITLE
ci: update CI for yarn v4

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -20,13 +20,13 @@ jobs:
         node-version: '20'
 
     - name: Install Dependencies
-      run: npm install
+      run: yarn install
 
     - name: Run Linter
-      run: npm run lint
+      run: yarn lint
 
   deploy:
-    name: Deploy to Production
+    name: Build # right now it's not doing any deploying, there's not even like, a webpage
     runs-on: ubuntu-latest
 
     steps:
@@ -39,10 +39,17 @@ jobs:
         node-version: '20'
 
     - name: Install Dependencies
-      run: npm install
+      run: yarn install
 
     - name: Build
-      run: npm run build
+      run: yarn build
+      
+    - name: Upload build result
+      uses: actions/upload-artifact@v4.3.3
+      with:
+        name: dist
+        path: dist/
+      
 
     - name: Deploy
       # Add your deployment steps here, such as deploying to a server or cloud provider


### PR DESCRIPTION
1. We have `yarn` now. No need for `npm install`
2. Run all scripts through `yarn`
3. Rename the workflow as it's not deploying anything yet.
4. After building, upload the compiled binary